### PR TITLE
Native footnote support and bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ TARGET=$(NAME).pdf
 DOCS_LINK=https://docs.google.com/document/d/1jp_z1cL3vtCdYa0ZPz6TR2JOtLi87Ur29O0nCSwJ3qA/export?format=txt
 
 # This line should not change; however, you can customize the template.tex for the conference
-PANDOC_FLAGS=-s -N --template=template.tex -f markdown+yaml_metadata_block -t latex
+#
+# We use "--tab-stop 3" as Google Docs indents nested lists with three spaces
+# (for markup, it's normally 4)
+PANDOC_FLAGS=-s -N --template=template.tex -f markdown+yaml_metadata_block+footnotes -t latex --tab-stop 3
 
 # Customize the line below to change the bib file and the csl file (either ieee or acm)
 # and to use pandoc-citeproc or biblatex (the latter is the default)
@@ -20,6 +23,11 @@ BIBLIO_FLAGS=--bibliography=mybib.bib --biblatex
 .SUFFIXES:
 .SUFFIXES: .stamp .tex .pdf
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	SED_REGEXP_FLAGS += -E
+endif
+
 top: all
 
 recompile: $(TARGET)
@@ -27,7 +35,7 @@ recompile: $(TARGET)
 all: trigger $(TARGET)
 
 clean:
-	rm -f $(NAME).aux $(NAME).bbl $(NAME).blg $(NAME).log $(NAME).pdf $(NAME).md $(NAME).out $(NAME).trig
+	rm -f $(NAME).aux $(NAME).bbl $(NAME).blg $(NAME).log $(NAME).pdf $(NAME).md $(NAME).out $(NAME).trig $(NAME).run.xml $(NAME).md-r $(NAME)-blx.bib
 	rm -f $(NAME).tex  # CAUTION remove if source is moved from Google docs
 
 trigger $(NAME).trig:
@@ -36,7 +44,19 @@ trigger $(NAME).trig:
 # This fetches the shared source from Google docs
 $(NAME).tex: $(NAME).trig
 	wget --no-check-certificate -O$(NAME).mdt $(DOCS_LINK)
-	iconv -c -t ASCII//TRANSLIT $(NAME).mdt | sed -e 's/\[[a-z]*]//g' -e '/^# Bibliography/q' -e '/%/a\ ' | awk '{if (/^#/) print ""; print $0}' > $(NAME).md
+	# `awk '{if (/^#/) print ""; print $0}'` adds a new line before any
+	#  section heading (begins with #)
+	iconv -c -t ASCII//TRANSLIT $(NAME).mdt | awk '{if (/^#/) print ""; print $0}' > $(NAME).md
+	# Footnote support for Google Docs
+	#   - `s/\[([0-9]+)\]/\[^\1\]/g` adds a `^` to the beginning of
+	#      Google Docs footnote marks ([1] -> [^1])
+	#   - `s/^(\[\^[0-9]+\])/\1:/g` adds a `:` after the closing bracket
+	#      for footnote marks at the beginning of the line, which is used
+	#      when defining the footnote's text at the end of the textfile
+	#      exported from Google Docs
+	#   - `s/^_{16}//` trims the ______________ that appears before
+	#      the footnotes in Google Docs text export
+	sed -i -r $(SED_REGEXP_FLAGS) 's/\[([0-9]+)\]/\[^\1\]/g; s/^(\[\^[0-9]+\])/\1:/g; s/^_{16}//' $(NAME).md
 	rm $(NAME).mdt
 	pandoc $(PANDOC_FLAGS) $(BIBLIO_FLAGS) $(NAME).md > $(NAME).tex
 


### PR DESCRIPTION
**Support for native Google Docs footnotes:**
- Allows footnotes in a Google Docs document to be translated into LaTeX automagically.
- This requires a new `sed` expression that adds a `^` before the footnote number in the plain text formatting that Google Docs exports. For instance, Google Docs exports `[1]`, but we need to translate it to `[^1]`. This also requires removing the `sed` logic that was dropping all lines after `# Bibliography`, as the footnotes will be exported below.

**Bug fixes:**
- Fixes intended lists by adding `--tab-stop 3` to Pandoc flags (as Google Docs indents lists with three spaces, not the four Pandoc expects)
- Fixes figure / table formatting logic by removing `sed -e 's/\[[a-z]*]//g'`. This expression appeared to be removing instances of bracketed characters, including `[t]` or `[tb]` for table formatting. It may have been needed in the past if the URL used for exporting the document was based on the pattern shown in [1]. Although very similar to the export URL used in the example Makefile, the URL in [1] exports a textfile that contains inline comments (which could be removed with this sed expression). However, when text is exported via the URL pattern shown in [2], inline comments are not included,.

[1] : `https://docs.google.com/document/export?format=txt&id=$DOCID`
[2] : `https://docs.google.com/document/d/$DOCID/export?format=txt`

**Cleanup:**
- Removes `sed -e '/%/a\ '`. I cannot identify the reason for this operation. It appears to be appending a new line following any line containing a `%` character, but these appends seem to have broken lists containing `%`, causing them to be split into multiple lists.